### PR TITLE
In NoSleepVideo, move currentTime to 0.5 or earlier

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -160,6 +160,17 @@ class NoSleepVideo implements INoSleep {
   }
 }
 
+/**
+ * Factory method to force creation of the video-based implementation of NoSleep.
+ * Useful for simulating a browser/platform where video is used from another
+ * browser where it is not.
+ */
+export const createNoSleepVideo = (options?: {
+  videoTitle?: string;
+  videoSourceType?: 'webm' | 'mp4';
+  onLogEvent?: LogEventCallback;
+}): INoSleep => new NoSleepVideo(options);
+
 type LogEventCallback = (
   message: string,
   level: string,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sgilroy/no-sleep",
+  "name": "@scottjgilroy/no-sleep",
   "version": "0.14.0",
   "author": "Scott Gilroy <scottjgilroy@gmail.com>",
   "contributors": [
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/zakj/NoSleep.js.git"
+    "url": "https://github.com/sgilroy/no-sleep.git"
   },
   "prettier": "@zakj/prettier-config",
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scottjgilroy/no-sleep",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "author": "Scott Gilroy <scottjgilroy@gmail.com>",
   "contributors": [
     "Rich Tibbett",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scottjgilroy/no-sleep",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "author": "Scott Gilroy <scottjgilroy@gmail.com>",
   "contributors": [
     "Rich Tibbett",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scottjgilroy/no-sleep",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "author": "Scott Gilroy <scottjgilroy@gmail.com>",
   "contributors": [
     "Rich Tibbett",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@zakj/no-sleep",
-  "version": "0.13.5",
+  "name": "@sgilroy/no-sleep",
+  "version": "0.14.0",
   "author": "Zak Johnson <me@zakj.net> (https://zakj.net)",
   "contributors": [
     "Rich Tibbett"
@@ -34,9 +34,9 @@
     "vite": "^4.4.11",
     "vite-plugin-dts": "^3.6.0"
   },
-  "homepage": "https://github.com/zakj/NoSleep.js",
+  "homepage": "https://github.com/sgilroy/no-sleep",
   "bugs": {
-    "url": "https://github.com/zakj/NoSleep.js/issues"
+    "url": "https://github.com/sgilroy/no-sleep/issues"
   },
   "type": "module",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@sgilroy/no-sleep",
   "version": "0.14.0",
-  "author": "Zak Johnson <me@zakj.net> (https://zakj.net)",
+  "author": "Scott Gilroy <scottjgilroy@gmail.com>",
   "contributors": [
-    "Rich Tibbett"
+    "Rich Tibbett",
+    "Zak Johnson <me@zakj.net> (https://zakj.net)"
   ],
   "license": "MIT",
   "description": "Prevent display sleep and enable wake lock in any Android or iOS web browser",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scottjgilroy/no-sleep",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "author": "Scott Gilroy <scottjgilroy@gmail.com>",
   "contributors": [
     "Rich Tibbett",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scottjgilroy/no-sleep",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "author": "Scott Gilroy <scottjgilroy@gmail.com>",
   "contributors": [
     "Rich Tibbett",


### PR DESCRIPTION
In NoSleepVideo, move currentTime to 0.5 or earlier to mitigate failu\res on iOS standalone

* Revert to the API of the original NoSleep
* Support options including videoTItle